### PR TITLE
Fix for newer Go

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
-  - 1.3
-  - 1.4
+  - 1.5
+  - 1.6
   - tip
 install:
   - go get ./...

--- a/quickfix.go
+++ b/quickfix.go
@@ -8,11 +8,11 @@ import (
 	"strings"
 
 	"go/ast"
+	"go/importer"
 	"go/token"
+	"go/types"
 
 	"golang.org/x/tools/go/ast/astutil"
-	_ "golang.org/x/tools/go/gcimporter"
-	"golang.org/x/tools/go/types"
 )
 
 var (
@@ -182,6 +182,7 @@ func (c Config) QuickFixOnce() (bool, error) {
 		Error: func(err error) {
 			errs = append(errs, err)
 		},
+		Importer: importer.Default(),
 	}
 
 	_, err := config.Check("_quickfix", fset, files, c.TypeInfo)

--- a/quickfix_test.go
+++ b/quickfix_test.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"fmt"
 	"go/ast"
+	"go/importer"
 	"go/parser"
 	"go/printer"
 	"go/token"
-	"golang.org/x/tools/go/types"
+	"go/types"
 	"strings"
 	"testing"
 )
@@ -83,7 +84,8 @@ func checkCorrectness(t *testing.T, testName string) {
 
 	logFiles(t, fset, files)
 
-	_, err = types.Check("testdata/"+testName, fset, files)
+	config := types.Config{Importer: importer.Default()}
+	_, err = config.Check("testdata/"+testName, fset, files, nil)
 	if err != nil {
 		t.Fatalf("should pass type checking: %s", err)
 	}


### PR DESCRIPTION
golang.org/x/tools/go/{types,gcimporter} were gone and they are
standard packages now.

See also
- https://groups.google.com/forum/#!topic/golang-announce/qu_rAphYdxY
