### PR TITLE
support go module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/motemen/go-quickfix
+
+go 1.13
+
+require golang.org/x/tools v0.0.0-20191205133340-d1f10d1c4e25

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/tools v0.0.0-20191205133340-d1f10d1c4e25 h1:5VU6vFy0xiB4WoxBoqfqmwg9g5eN0R5Az3Xfzo1EhO4=
+golang.org/x/tools v0.0.0-20191205133340-d1f10d1c4e25/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/quickfix.go
+++ b/quickfix.go
@@ -8,11 +8,11 @@ import (
 	"strings"
 
 	"go/ast"
-	"go/importer"
 	"go/token"
 	"go/types"
 
 	"golang.org/x/tools/go/ast/astutil"
+	"golang.org/x/tools/go/packages"
 )
 
 var (
@@ -173,6 +173,22 @@ func (c Config) RevertQuickFix() (err error) {
 	return
 }
 
+type pkgsImporter struct{}
+
+func (i pkgsImporter) Import(path string) (*types.Package, error) {
+	mode := packages.NeedTypes | packages.NeedImports | packages.NeedDeps
+	pkgs, err := packages.Load(&packages.Config{Mode: mode}, path)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(pkgs) == 0 {
+		return nil, fmt.Errorf("path %s not found", path)
+	}
+
+	return pkgs[0].Types, nil
+}
+
 func (c Config) QuickFixOnce() (bool, error) {
 	fset := c.Fset
 	files := c.Files
@@ -182,7 +198,7 @@ func (c Config) QuickFixOnce() (bool, error) {
 		Error: func(err error) {
 			errs = append(errs, err)
 		},
-		Importer: importer.Default(),
+		Importer: pkgsImporter{},
 	}
 
 	_, err := config.Check("_quickfix", fset, files, c.TypeInfo)


### PR DESCRIPTION
the go/importer does not support go module, use the golang.org/x/tools/go/packages instead.

however, go/packages is a little slow!