### PR TITLE
require packages.NeedDeps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/motemen/go-quickfix
 
 go 1.13
 
-require golang.org/x/tools v0.0.0-20191230220329-2aa90c603ae3
+require golang.org/x/tools v0.0.0-20200117220505-0cba7a3a9ee9

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,6 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/tools v0.0.0-20191230220329-2aa90c603ae3 h1:2+KluhQfJ1YhW+TB1KrISS2SfiG1pLEoseB0D4VF/bo=
-golang.org/x/tools v0.0.0-20191230220329-2aa90c603ae3/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200117220505-0cba7a3a9ee9 h1:KOkk4e2xd5OeCDJGwacvr75ICCbCsShrHiqPEdsA9hg=
+golang.org/x/tools v0.0.0-20200117220505-0cba7a3a9ee9/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/quickfix.go
+++ b/quickfix.go
@@ -183,7 +183,7 @@ type pkgsImporter struct {
 
 func (i pkgsImporter) Import(path string) (*types.Package, error) {
 	pkgs, err := packages.Load(&packages.Config{
-		Mode: packages.NeedTypes,
+		Mode: packages.NeedTypes | packages.NeedDeps,
 		Dir:  i.dir,
 	}, path)
 	if err != nil {


### PR DESCRIPTION
This should fix https://github.com/motemen/gore/issues/172. Note that `rootIndex >= 0` is changed to `rootIndex >= 0 || ld.Mode&NeedDeps != 0` at https://github.com/golang/tools/commit/84cebe10344f1cd161b47a7087b7979c67beab95#diff-04792145c70ebd708928684da4875fe9R522. Updates #8.